### PR TITLE
Fix: Mobile keyboard not appearing for text inputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
     <link type="image/x-icon" rel="shortcut icon" href="favicon.ico" />
   </head>
   <body>
+    <input type="text" id="hidden-input" style="position:absolute; top:-9999px; left:-9999px;">
     <a id="version"></a>
     <script src="version.js"></script>
   </body>

--- a/ui.js
+++ b/ui.js
@@ -20,8 +20,19 @@ class UI{
                 // textInput.focus();
                 UI.inputData.value = this.value;
                 UI.inputData.maxLength = charLimit;
+                if (hiddenInput) { // Ensure hiddenInput is defined
+                    if (charLimit) {
+                        hiddenInput.maxLength = charLimit;
+                    } else {
+                        hiddenInput.removeAttribute('maxlength');
+                    }
+                }
                 UI.inputData.cursor = UI.inputData.selectionStart = UI.inputData.selectionEnd = this.value.length;
                 UI.focusedInput = this;
+                if (hiddenInput) { // Ensure hiddenInput is defined
+                    hiddenInput.value = UI.inputData.value;
+                    hiddenInput.focus();
+                }
                 if(onclick instanceof Function) onclick.call(this,UI.focusedInput===this);
             };
             this.textCanvas = createBuffer(this.width,this.height);
@@ -283,6 +294,9 @@ UI.click = function(){
         return false;
     else if(UI.focusedInput){
         UI.focusedInput.value = UI.inputData.value;
+        if (hiddenInput) { // Ensure hiddenInput is defined
+            hiddenInput.blur();
+        }
         UI.focusedInput = undefined;
     }
     if(UI.mouseOver){
@@ -298,6 +312,23 @@ UI.viewBasin = undefined;
 // Definitions for all UI elements
 
 UI.init = function(){
+    let hiddenInput = document.getElementById('hidden-input');
+
+    if (hiddenInput) {
+        hiddenInput.addEventListener('input', function() {
+            if (UI.focusedInput && UI.focusedInput.isInput) {
+                UI.inputData.value = hiddenInput.value;
+                // If the canvas doesn't update automatically, we might need to force a re-render
+                // or ensure the main draw loop picks up changes in UI.inputData.value.
+                // For now, let's assume the existing rendering logic for inputs will handle it.
+                // We also need to update the cursor and selection properties in UI.inputData
+                // to match the hidden input's state.
+                UI.inputData.cursor = hiddenInput.selectionStart;
+                UI.inputData.selectionStart = hiddenInput.selectionStart;
+                UI.inputData.selectionEnd = hiddenInput.selectionEnd;
+            }
+        });
+    }
     // hoist!
 
     let yearselbox;
@@ -2284,12 +2315,18 @@ function keyPressed(){
             case ESCAPE:
                 // textInput.value = UI.focusedInput.value;
                 // textInput.blur();
+                if (hiddenInput) { // Ensure hiddenInput is defined
+                    hiddenInput.blur();
+                }
                 UI.focusedInput = undefined;
                 break;
             case ENTER:
                 let u = UI.focusedInput;
                 // textInput.blur();
                 u.value = UI.inputData.value;
+                if (hiddenInput) { // Ensure hiddenInput is defined
+                    hiddenInput.blur();
+                }
                 UI.focusedInput = undefined;
                 if(u.enterFunc) u.enterFunc();
                 break;


### PR DESCRIPTION
Previously, the Textbox input for name, year, and the designation list did not trigger the keyboard on mobile devices. This was because these inputs were custom-implemented using canvas drawing and JavaScript-based event handling, which doesn't inherently trigger the mobile keyboard.

This commit introduces a hidden HTML input element that is focused when a canvas-based input is selected. The native mobile keyboard interacts with this hidden input, and its value is synchronized with the canvas input, enabling text entry on mobile devices.

Changes include:
- Added a hidden text input to index.html.
- Modified ui.js to:
  - Focus/blur the hidden input when canvas inputs are focused/blurred.
  - Synchronize text between the hidden input and the canvas input.
  - Set maxLength property on the hidden input.